### PR TITLE
Fix `PostgresDriver::get` sqlx type shenanigans

### DIFF
--- a/src/database/postgres.rs
+++ b/src/database/postgres.rs
@@ -20,13 +20,12 @@ type PostgresValues = (String, Vec<u8>, String);
 #[async_trait]
 impl DatabaseTrait for PostgresDriver {
     async fn get(&self, identifier: String) -> ImoogResult<Option<MediaData>> {
-        let row: Option<PostgresValues> = sqlx::query_as("SELECT (identifier, media, mime) FROM imoog WHERE identifier = $1")
+        let row: Option<(PostgresValues,)> = sqlx::query_as("SELECT (identifier, media, mime) FROM imoog WHERE identifier = $1")
             .bind(identifier)
-            .fetch_one(&self.pool)
-            .await
-            .ok();
+            .fetch_optional(&self.pool)
+            .await?;
 
-        Ok(row.map(|x| {
+        Ok(row.map(|(x,)| {
             MediaData {
                 _id: x.0,
                 content: x.1,


### PR DESCRIPTION
The current implementation of `PostgresDriver::get` doesn't work, and turns errors into 404s. This makes it more consistent with errors throughout the app and makes the `PostgresDriver` work.